### PR TITLE
Automatically close stale Pull Requests

### DIFF
--- a/pyup/pullrequest.py
+++ b/pyup/pullrequest.py
@@ -4,11 +4,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 class PullRequest(object):
 
-    def __init__(self, state, title, url, created_at):
+    def __init__(self, state, title, url, created_at, number=None, issue=False):
         self.state = state
         self.title = title
         self.url = url
         self.created_at = created_at
+        self.number = number
+        self.issue = issue
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -28,3 +30,11 @@ class PullRequest(object):
     @property
     def is_open(self):
         return self.state == "open"
+
+    @property
+    def requirement(self):
+        if self.type != "initial":
+            parts = self.title.split(" ")
+            if len(parts) >= 2:
+                return parts[1].lower()
+        return None

--- a/tests/test_pullrequest.py
+++ b/tests/test_pullrequest.py
@@ -56,3 +56,22 @@ class PullRequestStateTest(TestCase):
         self.assertEqual(pr.is_open, False)
         pr.state = "open"
         self.assertEqual(pr.is_open, True)
+
+
+class PullRequestRequirementTestCase(TestCase):
+
+    def test_initial_non(self):
+        pr = pullrequest_factory(title="Initial PR")
+        self.assertEqual(pr.requirement, None)
+
+    def test_pin(self):
+        pr = pullrequest_factory(title="Pin django")
+        self.assertEqual(pr.requirement, "django")
+
+    def test_update(self):
+        pr = pullrequest_factory(title="Update django")
+        self.assertEqual(pr.requirement, "django")
+
+    def test_some_bogus(self):
+        pr = pullrequest_factory(title="Uhm?")
+        self.assertEqual(pr.requirement, None)


### PR DESCRIPTION
Closes stale pull requests for the given update, links to the new pull request and deletes
the stale branch.
        
A stale PR is a PR that:
- Is not merged
- Is not closed
- Has no commits (except the bot commit)