### PR TITLE
Initial Gitlab support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 Copyright (c) <year> <copyright holders>
+Copyright (c) 2017 Sam Parkinson <sam@sam.today>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,12 @@ This will create a new branch and a pull request for every single update. Run a 
 that auto-updates your repository once in a while (e.g. every day) to stay on latest.
 
 
+Pyup also has experimental support for Gitlab.  Generate a personal access token
+from your profile settings (eg. https://gitlab.com/profile/personal_access_tokens),
+then run pyup from the cli::
+
+    # gitlab.com:
+    $ pyup --repo=username/repo --user-token=<YOUR_TOKEN>
+
+    # other:
+    $ pyup --repo=username/repo --user-token=<YOUR_TOKEN>@https://your.gitlab/

--- a/pyup/cli.py
+++ b/pyup/cli.py
@@ -3,6 +3,7 @@ from pyup import __version__
 from pyup.bot import DryBot, Bot
 from pyup.requirements import RequirementFile, RequirementsBundle
 from pyup.providers.github import Provider as GithubProvider
+from pyup.providers.gitlab import Provider as GitlabProvider
 import click
 from tqdm import tqdm
 import logging
@@ -13,7 +14,7 @@ import logging
 @click.option('--repo', prompt='repository', help='')
 @click.option('--user-token', prompt='user token', help='')
 @click.option('--bot-token', help='', default=None)
-@click.option('--provider', help='', default="github")
+@click.option('--provider', help='API to use; either github or gitlab', default="github")
 @click.option('--dry', help='Run the bot without committing', default=False)
 @click.option('--branch', help='Set the branch the bot should use', default='master')
 @click.option('--initial', help='Set this to bundle all PRs into a large one',
@@ -26,6 +27,8 @@ def main(repo, user_token, bot_token, provider, dry, branch, initial, pin, close
 
     if provider == 'github':
         ProviderClass = GithubProvider
+    elif provider == 'gitlab':
+        ProviderClass = GitlabProvider
     else:
         raise NotImplementedError
 

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function
+import logging
+from gitlab import Gitlab
+from gitlab.exceptions import GitlabGetError, GitlabCreateError
+from ..errors import BranchExistsError, RepoDoesNotExistError
+from base64 import b64encode
+
+logger = logging.getLogger(__name__)
+
+
+class BadTokenError(Exception):
+    pass
+
+
+class Provider(object):
+    def __init__(self, bundle, intergration=False):
+        self.bundle = bundle
+        if intergration:
+            raise NotImplementedError(
+                'Gitlab provider does not support integration mode')
+
+    @classmethod
+    def is_same_user(cls, this, that):
+        return this.login == that.login
+
+    def _api(self, token):
+        parts = token.split('@')
+        if len(parts) == 1:
+            host = 'https://gitlab.com'
+            auth = parts[0]
+        elif len(parts) == 2:
+            auth, host = parts
+        else:
+            raise BadTokenError(
+                'Got token "{}": format should be wither "apikey" for '
+                'gitlab.com, or "apikey@https://yourgitlab.local"'.format(
+                    token))
+        return Gitlab(host, auth)
+
+    def get_user(self, token):
+        gl = self._api(token)
+        gl.auth()
+        return gl.user
+
+    def get_repo(self, token, name):
+        try:
+            return self._api(token).projects.get(name)
+        except GitlabGetError as e:
+            if e.response_code == 404:
+                raise RepoDoesNotExistError()
+            raise e
+
+    def get_default_branch(self, repo):
+        return repo.default_branch
+
+    def get_pull_request_permissions(self, user, repo):
+        # TODO: IDK how this works on gitlab
+        return True
+
+    def iter_git_tree(self, repo, branch):
+        for item in repo.repository_tree(ref=branch, recursive=True):
+            yield item['type'], item['path']
+
+    def get_file(self, repo, path, branch):
+        logger.info("Getting file at {} for branch {}".format(path, branch))
+        try:
+            contentfile = repo.files.get(file_path=path, ref=branch)
+        except GitlabGetError as e:
+            if e.response_code == 404:
+                logger.warning("Unable to get {path}".format(
+                    path=path,
+                ))
+                return None, None
+        else:
+            return contentfile.decode().decode("utf-8"), contentfile
+
+    def create_and_commit_file(self, repo, path, branch, content, commit_message, committer):
+
+        # TODO: committer
+        return repo.files.create({
+            'file_path': path,
+            'branch_name': branch,
+            'content': content,
+            'commit_message': commit_message
+        })
+
+    def get_requirement_file(self, repo, path, branch):
+        content, file_obj = self.get_file(repo, path, branch)
+        if content is not None and file_obj is not None:
+            return self.bundle.get_requirement_file_class()(
+                path=path,
+                content=content,
+            )
+        return None
+
+    def create_branch(self, repo, base_branch, new_branch):
+        try:
+            repo.branches.create({"branch_name": new_branch,
+                                  "ref": base_branch})
+        except GitlabCreateError as e:
+            if e.error_message == 'Branch already exists':
+                raise BranchExistsError(new_branch)
+
+    def is_empty_branch(self, repo, base_branch, new_branch, prefix):
+        """
+        Compares the top commits of two branches.
+        Please note: This function isn't checking if `base_branch` is a direct
+        parent of `new_branch`, see
+        http://stackoverflow.com/questions/3161204/find-the-parent-branch-of-a-git-branch
+        :param repo: github.Repository
+        :param base_branch: string name of the base branch
+        :param new_branch: string name of the new branch
+        :param prefix: string branch prefix, default 'pyup-'
+        :return: bool -- True if empty
+        """
+        # extra safeguard to make sure we are handling a bot branch here
+        assert new_branch.startswith(prefix)
+        comp = repo.repository_compare(base_branch, new_branch)
+        n = len(comp.commits)
+        logger.info("Got a total of {} commits in {}".format(n, new_branch))
+        return n == 0
+
+    def delete_branch(self, repo, branch, prefix):
+        """
+        Deletes a branch.
+        :param repo: github.Repository
+        :param branch: string name of the branch to delete
+        """
+        # make sure that the name of the branch begins with pyup.
+        assert branch.startswith(prefix)
+        obj = repo.branches.get(branch)
+        obj.delete()
+
+    def create_commit(self, path, branch, commit_message, content, sha, repo, committer):
+        # TODO: committer
+
+        f = repo.files.get(file_path=path, ref=branch)
+        # Gitlab supports a plaintext encoding, which is when the encoding
+        # value is unset.  Python-Gitlab seems to set it to b64, so we can't
+        # unset it unfortunately
+        f.content = b64encode(content.encode()).decode()
+        f.encoding = 'base64'
+        # TODO: committer
+        f.save(branch_name=branch, commit_message=commit_message)
+
+    def close_pull_request(self, bot_repo, user_repo, mr, comment, prefix):
+        mr.state_event = 'close'
+        mr.save()
+        mr.notes.create({'body': comment})
+
+        self.delete_branch(user_repo, mr.source_branch, prefix)
+
+    def create_pull_request(self, repo, title, body, base_branch, new_branch, pr_label, assignees):
+        # TODO: Check permissions
+        try:
+            if len(body) >= 65536:
+                logger.warning("PR body exceeds maximum length of 65536 chars, reducing")
+                body = body[:65536 - 1]
+
+            request = {
+                'source_branch': new_branch,
+                'target_branch': base_branch,
+                'title': title,
+                'description': body,
+            }
+            if pr_label is not None:
+                request['pr_label'] = pr_label
+            if assignees is not None:
+                request['assignee_id'] = assignees
+            mr = repo.mergerequests.create({
+                'source_branch': new_branch,
+                'target_branch': base_branch,
+                'title': title,
+                'description': body,
+                'pr_label': pr_label,
+            })
+
+            return self.bundle.get_pull_request_class()(
+                state=mr.state,
+                title=mr.title,
+                url=mr.web_url,
+                created_at=mr.created_at,
+                number=mr.iid,
+                issue=False
+            )
+        except GitlabCreateError as e:
+            if e.response_code == 409:
+                logger.warning(
+                    "PR {title} from {base_branch}->{new_branch} is already "
+                    "exists and is open, resorting to a comment "
+                    "instead".format(
+                        title=title, new_branch=new_branch,
+                        base_branch=base_branch))
+
+                comment = '# {title}\n{body}'.format(title=title, body=body)
+                # the exception doesn't say *which* MR is open, so we have to
+                # find it :(
+                for mr in repo.mergerequests.list(state='opened', all=True):
+                    if (mr.source_branch == new_branch and mr.target_branch == base_branch):
+                        mr.notes.create({'body': comment})
+                        return self.bundle.get_pull_request_class()(
+                            state=mr.state,
+                            title=mr.title,
+                            url=mr.web_url,
+                            created_at=mr.created_at,
+                            number=mr.iid,
+                            issue=False
+                        )
+
+    def create_issue(self, repo, title, body):
+        return repo.issues.create({
+            'title': title,
+            'description': body
+        })
+
+    def iter_issues(self, repo, creator):
+        # TODO: handle creator
+        for issue in repo.issues.list():
+            yield self.bundle.get_pull_request_class()(
+                state=issue.state,
+                title=issue.title,
+                url=issue.web_url,
+                created_at=issue.created_at,
+                number=issue.iid,
+                issue=True,
+            )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ requirements = [
     "hashin-pyup",
     "packaging",
     "six",
-    "setuptools<=26.1.1"
+    "setuptools<=26.1.1",
+    "python-gitlab"
 ]
 
 test_requirements = [

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+from unittest import TestCase
+from unittest import skip
+from pyup.providers.gitlab import Provider
+from pyup.requirements import RequirementsBundle
+from pyup import errors
+from mock import Mock, patch, PropertyMock
+from base64 import b64encode
+
+from gitlab.exceptions import GitlabGetError
+
+
+class ProviderTest(TestCase):
+
+    def setUp(self):
+        self.provider = Provider(bundle=Mock())
+        self.provider._api = Mock()
+        self.repo = Mock()
+
+    def test_is_same_user(self):
+        this = Mock()
+        this.login = "this"
+
+        that = Mock()
+        that.login = "that"
+
+        self.assertFalse(Provider.is_same_user(this, that))
+
+        that.login = "this"
+
+        self.assertTrue(Provider.is_same_user(this, that))
+
+    @patch("pyup.providers.gitlab.Gitlab")
+    def test_api(self, github_mock):
+        prov = Provider(bundle=RequirementsBundle())
+        prov._api("foo")
+        github_mock.assert_called_once_with("https://gitlab.com", "foo")
+
+    @patch("pyup.providers.gitlab.Gitlab")
+    def test_api_different_host(self, github_mock):
+        prov = Provider(bundle=RequirementsBundle())
+        prov._api("foo@localhost")
+        github_mock.assert_called_once_with("localhost", "foo")
+
+    def test_get_user(self):
+        self.provider.get_user("foo")
+        self.provider._api().auth.assert_called_once_with()
+
+    def test_get_repo(self):
+        self.provider.get_repo("token", "name")
+        self.provider._api().projects.get.assert_called_once_with("name")
+
+    def test_get_repo_404(self):
+        self.provider._api().projects.get.side_effect = \
+            GitlabGetError(response_code=404)
+        with self.assertRaises(errors.RepoDoesNotExistError):
+            self.provider.get_repo("token", "name")
+
+    def test_get_default_branch(self):
+        self.repo.default_branch = "foo"
+        self.assertEqual(
+            self.provider.get_default_branch(self.repo),
+            "foo"
+        )
+
+    @skip
+    def test_get_pull_request_permissions(self):
+        # TODO: PORT
+        user = Mock()
+        user.login = "some-dude"
+        self.provider.get_pull_request_permissions(user, self.repo)
+        self.repo.add_to_collaborators.assert_called_once_with("some-dude")
+
+        self.repo.add_to_collaborators.side_effect = GithubException(data="", status=1)
+        with self.assertRaises(errors.NoPermissionError):
+            self.provider.get_pull_request_permissions(user, self.repo)
+
+    def test_iter_git_tree(self):
+        mocked_items = [{"type": "type", "path": "path"}]
+        self.repo.repository_tree.return_value = mocked_items
+        items = list(self.provider.iter_git_tree(self.repo, "some branch"))
+        self.repo.repository_tree.assert_called_with(ref="some branch",
+                                                     recursive=True)
+        self.assertEqual(items, [("type", "path")])
+
+    def test_get_file(self):
+        content, obj = self.provider.get_file(self.repo, "path", "branch")
+        self.assertIsNotNone(content)
+        self.assertIsNotNone(obj)
+        self.repo.files.get.assert_called_with(file_path="path", ref="branch")
+
+    def test_get_requirement_file(self):
+        req = self.provider.get_requirement_file(self.repo, "path", "branch")
+        self.assertIsNotNone(req)
+        self.provider.bundle.get_requirement_file_class.assert_called_once_with()
+        self.assertEquals(self.provider.bundle.get_requirement_file_class().call_count, 1)
+
+        self.provider.get_file = Mock(return_value = (None, None))
+        req = self.provider.get_requirement_file(self.repo, "path", "branch")
+        self.assertIsNone(req)
+
+    def test_create_branch(self):
+        self.provider.create_branch(self.repo, "base branch", "new branch")
+        self.repo.branches.create.assert_called_with(
+            {"branch_name": "new branch", "ref": "base branch"})
+
+    def test_is_empty_branch(self):
+        with self.assertRaises(AssertionError):
+            self.provider.is_empty_branch(self.repo, "master", "foo", prefix="bar")
+
+        self.repo.repository_compare().commits = []
+        self.assertTrue(
+            self.provider.is_empty_branch(self.repo, "master", "pyup-foo", prefix="pyup-")
+        )
+
+        self.repo.repository_compare().commits = []
+        self.assertTrue(
+            self.provider.is_empty_branch(self.repo, "master", "pyup/foo", prefix="pyup/")
+        )
+
+        self.repo.repository_compare().commits = [Mock()]
+        self.assertFalse(
+            self.provider.is_empty_branch(self.repo, "master", "pyup-foo", prefix="pyup-")
+        )
+
+    def test_delete_branch(self):
+        with self.assertRaises(AssertionError):
+            self.provider.delete_branch(self.repo, "foo", prefix="bar")
+
+        self.provider.delete_branch(self.repo, "pyup-foo", prefix="pyup-")
+        self.repo.branches.get.assert_called_with("pyup-foo")
+        self.repo.branches.get().delete.assert_called_with()
+
+        self.provider.delete_branch(self.repo, "pyup/foo", prefix="pyup/")
+        self.repo.branches.get.assert_called_with("pyup/foo")
+        self.repo.branches.get().delete.assert_called_with()
+
+    @patch("pyup.providers.github.time")
+    def test_create_commit(self, time):
+        file = Mock()
+        self.repo.files.get.return_value = file
+        self.provider.create_commit("path", "branch", "commit", "content", "sha", self.repo, "com")
+        self.assertEquals(self.repo.files.get.call_count, 1)
+        self.assertEquals(file.content, b64encode(b"content").decode())
+        self.assertEquals(file.encoding, "base64")
+        file.save.assert_called_with(branch_name="branch", commit_message="commit")
+
+    def test_create_and_commit_file(self):
+        repo = Mock()
+        path, branch, content, commit_message, committer = (
+            '/foo.txt',
+            'some-branch',
+            'content',
+            'some-message',
+            'johnny'
+        )
+        data = self.provider.create_and_commit_file(
+            repo=repo,
+            path=path,
+            commit_message=commit_message,
+            branch=branch,
+            content=content,
+            committer=committer
+        )
+        repo.files.create.assert_called_once_with({
+            'file_path': path,
+            'branch_name': branch,
+            'content': content,
+            'commit_message': commit_message
+        })
+
+    def test_close_pull_request(self):
+        mr = Mock()
+        mr.source_branch = 'blah'
+        with self.assertRaises(AssertionError):
+            self.provider.close_pull_request(self.repo, self.repo, mr, "comment", prefix="pyup-")
+
+        mr.source_branch = "pyup-bla"
+        self.provider.close_pull_request(self.repo, self.repo, mr, "comment", prefix="pyup-")
+        self.assertEquals(self.repo.branches.get().delete.call_count, 1)
+
+
+    def test_create_pull_request_with_exceeding_body(self):
+        body = ''.join(["a" for i in range(0, 65536 + 1)])
+        self.provider.create_pull_request(self.repo, "title", body, "master", "new", False, [])
+        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+
+    def test_create_pull_request(self):
+        self.provider.create_pull_request(self.repo, "title", "body", "master", "new", False, [])
+        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+
+    def test_create_pull_request_with_label(self):
+        self.provider.create_pull_request(self.repo, "title", "body", "master", "new", "some-label", [])
+        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+
+    def test_create_issue(self):
+        self.assertIsNot(self.provider.create_issue(self.repo, "title", "body"), False)
+
+    def test_iter_issues(self):
+        self.repo.issues.list.return_value = [Mock(), Mock()]
+        issues = list(self.provider.iter_issues(self.repo, Mock()))
+        self.assertEqual(len(issues), 2)


### PR DESCRIPTION
This commit adds gitlab support via the Provider abstraction.  It can
now be used via (for gitlab.com):

    pyup --provider gitlab --user-token blah

Or for other gitlabs:

    pyup --provider gitlab --user-token blah@https://gitlab.local

The implementation is pretty first pass; there are some errors that it
probably does not handle.  It does not support integration mode, only
CLI mode.