### PR TITLE
Customizeable commit messages

### DIFF
--- a/pyup/config.py
+++ b/pyup/config.py
@@ -22,6 +22,9 @@ SCHEDULE_REGEX = re.compile(
 
 class Config(object):
 
+    COMMIT_PIN_MSG = "Pin {name} to latest version {new_version}"
+    COMMIT_UPDATE_MSG = "Update {name} from {old_version} to {new_version}"
+
     UPDATE_ALL = "all"
     UPDATE_INSECURE = "insecure"
     # the docs had a typo at some point that incorrectly reffered to 'security'

--- a/pyup/config.py
+++ b/pyup/config.py
@@ -22,9 +22,6 @@ SCHEDULE_REGEX = re.compile(
 
 class Config(object):
 
-    COMMIT_PIN_MSG = "Pin {name} to latest version {new_version}"
-    COMMIT_UPDATE_MSG = "Update {name} from {old_version} to {new_version}"
-
     UPDATE_ALL = "all"
     UPDATE_INSECURE = "insecure"
     # the docs had a typo at some point that incorrectly reffered to 'security'
@@ -36,6 +33,8 @@ class Config(object):
         self.close_prs = True
         self.branch = "master"
         self.branch_prefix = "pyup-"
+        self.commit_msg_pin = "Pin {name} to latest version {new_version}"
+        self.commit_msg_update = "Update {name} from {old_version} to {new_version}"
         self.pr_prefix = ""
         self.pin = True
         self.search = True

--- a/pyup/updates.py
+++ b/pyup/updates.py
@@ -45,16 +45,17 @@ class Update(dict):
         else:
             self[key] = [update]
 
-    @classmethod
-    def get_commit_message(cls, requirement):
+    def get_commit_message(self, requirement):
         if requirement.is_pinned:
-            return "Update {} from {} to {}".format(
-                requirement.key, requirement.version,
-                requirement.latest_version_within_specs
+            return self.config.COMMIT_UPDATE_MSG.format(
+                name=requirement.key,
+                old_version=requirement.version,
+                new_version=requirement.latest_version_within_specs
             )
-        return "Pin {} to latest version {}".format(
-            requirement.key,
-            requirement.latest_version_within_specs
+        return self.config.COMMIT_PIN_MSG.format(
+            name=requirement.key,
+            old_version=requirement.version,
+            new_version=requirement.latest_version_within_specs
         )
 
     def should_update(self, requirement, requirement_file):

--- a/pyup/updates.py
+++ b/pyup/updates.py
@@ -47,12 +47,12 @@ class Update(dict):
 
     def get_commit_message(self, requirement):
         if requirement.is_pinned:
-            return self.config.COMMIT_UPDATE_MSG.format(
+            return self.config.commit_msg_update.format(
                 name=requirement.key,
                 old_version=requirement.version,
                 new_version=requirement.latest_version_within_specs
             )
-        return self.config.COMMIT_PIN_MSG.format(
+        return self.config.commit_msg_pin.format(
             name=requirement.key,
             old_version=requirement.version,
             new_version=requirement.latest_version_within_specs

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -111,6 +111,29 @@ class UpdateGetCommitMessageTest(UpdateBaseTest):
         self.assertEqual(self.update.get_commit_message(req), "Update django from 1.0 to 1.10")
 
 
+class UpdateGetCommitMessageTest(UpdateBaseTest):
+    def setUp(self):
+        self.config = Config()
+        self.config.commit_msg_pin = "{name} has been pinned to version {new_version}"
+        self.config.commit_msg_update = "{name} was version {old_version} and is now {new_version}"
+        self.update = Update([], self.config)
+
+    def test_unpinned_requirement(self):
+        req = Mock()
+        req.key = "django"
+        req.is_pinned = False
+        req.latest_version_within_specs = "1.10"
+        self.assertEqual(self.update.get_commit_message(req), "django has been pinned to version 1.10")
+
+    def test_pinned_requirement(self):
+        req = Mock()
+        req.key = "django"
+        req.is_pinned = True
+        req.latest_version_within_specs = "1.10"
+        req.version = "1.0"
+        self.assertEqual(self.update.get_commit_message(req), "django was version 1.0 and is now 1.10")
+
+
 class UpdateInitTestCase(UpdateBaseTest):
     def test_init_empty(self):
         update = Update([], self.config)

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -91,12 +91,16 @@ class UpdateCreateUpdateKeyTest(UpdateBaseTest):
 
 
 class UpdateGetCommitMessageTest(UpdateBaseTest):
+    def setUp(self):
+        self.config = Config()
+        self.update = Update([], self.config)
+
     def test_unpinned_requirement(self):
         req = Mock()
         req.key = "django"
         req.is_pinned = False
         req.latest_version_within_specs = "1.10"
-        self.assertEqual(Update.get_commit_message(req), "Pin django to latest version 1.10")
+        self.assertEqual(self.update.get_commit_message(req), "Pin django to latest version 1.10")
 
     def test_pinned_requirement(self):
         req = Mock()
@@ -104,7 +108,7 @@ class UpdateGetCommitMessageTest(UpdateBaseTest):
         req.is_pinned = True
         req.latest_version_within_specs = "1.10"
         req.version = "1.0"
-        self.assertEqual(Update.get_commit_message(req), "Update django from 1.0 to 1.10")
+        self.assertEqual(self.update.get_commit_message(req), "Update django from 1.0 to 1.10")
 
 
 class UpdateInitTestCase(UpdateBaseTest):


### PR DESCRIPTION
Hi @jayfk! We spoke via email a while ago about allowing for customizable commit messages; this PR is meant to implement that feature.

This commit allows for commit messages to be modified in `.pyup.yml`. The [documentation](https://pyup.io/docs/bot/config/) will need to be updated with something like the following blob:

```
# configure commit messages for pinned dependencies
# default: "Pin {name} to latest version {new_version}"
# allowed: any string containing format strings {name}, {old_version}, and/or {new_version}
commit_msg_pin: "Pin {name} to latest version {new_version}"

# configure commit messages for un-pinned dependencies
# default: "Update {name} from {old_version} to {new_version}"
# allowed: any string containing format strings {name}, {old_version}, and/or {new_version}
commit_msg_update: "Update {name} from {old_version} to {new_version}"
```

I did not see any method of updating the docs from this code-base (did I miss something in `docs/`?), but would be happy to do that update if you could point me in the right direction.