### PR TITLE
Update classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,12 +59,14 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
+        "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Python 2.6 was dropped in https://github.com/pyupio/pyup/commit/b2f2c0b303b96a05ea23cf51d328554b49af7abb#diff-354f30a63fb0907d4ad57269548329e3.