### PR TITLE
Switch to Gitlab API v4

### DIFF
--- a/pyup/bot.py
+++ b/pyup/bot.py
@@ -412,7 +412,7 @@ class Bot(object):
                                                                    "content": content}
                 else:
                     logger.error("Empty commit at {repo}, unable to update {title}.".format(
-                        repo=self.user_repo.full_name, title=title)
+                        repo=self.user_repo.path_with_namespace, title=title)
                     )
 
             if updated_files:

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -59,7 +59,7 @@ class Provider(object):
         return True
 
     def iter_git_tree(self, repo, branch):
-        for item in repo.repository_tree(ref=branch, recursive=True):
+        for item in repo.repository_tree(ref=branch, recursive=True, all=True):
             yield item['type'], item['path']
 
     def get_file(self, repo, path, branch):

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -80,7 +80,7 @@ class Provider(object):
         # TODO: committer
         return repo.files.create({
             'file_path': path,
-            'branch_name': branch,
+            'branch': branch,
             'content': content,
             'commit_message': commit_message
         })
@@ -96,7 +96,7 @@ class Provider(object):
 
     def create_branch(self, repo, base_branch, new_branch):
         try:
-            repo.branches.create({"branch_name": new_branch,
+            repo.branches.create({"branch": new_branch,
                                   "ref": base_branch})
         except GitlabCreateError as e:
             if e.error_message == 'Branch already exists':
@@ -142,7 +142,7 @@ class Provider(object):
         f.content = b64encode(content.encode()).decode()
         f.encoding = 'base64'
         # TODO: committer
-        f.save(branch_name=branch, commit_message=commit_message)
+        f.save(branch=branch, commit_message=commit_message)
 
     def close_pull_request(self, bot_repo, user_repo, mr, comment, prefix):
         mr.state_event = 'close'

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -97,7 +97,7 @@ class ProviderTest(TestCase):
     def test_create_branch(self):
         self.provider.create_branch(self.repo, "base branch", "new branch")
         self.repo.branches.create.assert_called_with(
-            {"branch_name": "new branch", "ref": "base branch"})
+            {"branch": "new branch", "ref": "base branch"})
 
     def test_is_empty_branch(self):
         with self.assertRaises(AssertionError):
@@ -138,7 +138,7 @@ class ProviderTest(TestCase):
         self.assertEquals(self.repo.files.get.call_count, 1)
         self.assertEquals(file.content, b64encode(b"content").decode())
         self.assertEquals(file.encoding, "base64")
-        file.save.assert_called_with(branch_name="branch", commit_message="commit")
+        file.save.assert_called_with(branch="branch", commit_message="commit")
 
     def test_create_and_commit_file(self):
         repo = Mock()
@@ -159,7 +159,7 @@ class ProviderTest(TestCase):
         )
         repo.files.create.assert_called_once_with({
             'file_path': path,
-            'branch_name': branch,
+            'branch': branch,
             'content': content,
             'commit_message': commit_message
         })

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -75,6 +75,7 @@ class ProviderTest(TestCase):
         self.repo.repository_tree.return_value = mocked_items
         items = list(self.provider.iter_git_tree(self.repo, "some branch"))
         self.repo.repository_tree.assert_called_with(ref="some branch",
+                                                     all=True,
                                                      recursive=True)
         self.assertEqual(items, [("type", "path")])
 


### PR DESCRIPTION
Modern Gitlab instances uses v4 by default and it's recommended one
to be used:
https://docs.gitlab.com/ce/api/v3_to_v4.html

The main differences comes in how branch parameter get used:
http://python-gitlab.readthedocs.io/en/stable/gl_objects/branches.html