### PR TITLE
Add provider_url option and support for GitHub Enterprise

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Christophe Lecointe

--- a/README.rst
+++ b/README.rst
@@ -79,5 +79,13 @@ then run pyup from the cli::
     # gitlab.com:
     $ pyup --provider gitlab --repo=username/repo --user-token=<YOUR_TOKEN>
 
-    # other:
+Custom Gitlab instance and GitHub Enterprise support
+----------------------------------------------------
+
+Pyup offer support for custom Gitlab instances and GitHub Enterprise via the provider_url option :
+
+    $ pyup --provider github --provider_url https://github.enterprise/api/v3 --repo=username/repo --user-token=<YOUR_TOKEN>
+    $ pyup --provider gitlab --provider_url https://your.gitlab/ --repo=username/repo --user-token=<YOUR_TOKEN>
+
+    # The alternative method to add a custom gitlab instance is still valid :
     $ pyup --provider gitlab --repo=username/repo --user-token=<YOUR_TOKEN>@https://your.gitlab/

--- a/pyup/bot.py
+++ b/pyup/bot.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 class Bot(object):
     def __init__(self, repo, user_token, bot_token=None,
                  provider=GithubProvider, bundle=RequirementsBundle, config=Config,
-                 integration=False):
+                 integration=False, provider_url=None):
         self.req_bundle = bundle()
-        self.provider = provider(self.req_bundle, integration)
+        self.provider = provider(self.req_bundle, integration, provider_url)
         self.user_token = user_token
         self.bot_token = bot_token
         self.fetched_files = []

--- a/pyup/cli.py
+++ b/pyup/cli.py
@@ -19,11 +19,12 @@ import logging
               help="API Key for pyup.io's vulnerability database. Can be set as SAFETY_API_KEY "
                    "environment variable. Default: empty")
 @click.option('--provider', help='API to use; either github or gitlab', default="github")
+@click.option('--provider_url', help='Optional custom URL to your provider', default=None)
 @click.option('--branch', help='Set the branch the bot should use', default='master')
 @click.option('--initial', help='Set this to bundle all PRs into a large one',
               default=False, is_flag=True)
 @click.option('--log', help='Set the log level', default="ERROR")
-def main(repo, user_token, bot_token, key, provider, branch, initial, log):
+def main(repo, user_token, bot_token, key, provider, provider_url, branch, initial, log):
     logging.basicConfig(level=getattr(logging, log.upper(), None))
 
     settings.configure(key=key)
@@ -40,6 +41,7 @@ def main(repo, user_token, bot_token, key, provider, branch, initial, log):
         user_token=user_token,
         bot_token=bot_token,
         provider=ProviderClass,
+        provider_url=provider_url,
     )
 
     bot.update(branch=branch, initial=initial)
@@ -52,9 +54,9 @@ if __name__ == '__main__':
 class CLIBot(Bot):
 
     def __init__(self, repo, user_token, bot_token=None,
-                 provider=GithubProvider, bundle=RequirementsBundle):
+                 provider=GithubProvider, bundle=RequirementsBundle, provider_url=None):
         bundle = CLIBundle
-        super(CLIBot, self).__init__(repo, user_token, bot_token, provider, bundle)
+        super(CLIBot, self).__init__(repo, user_token, bot_token, provider, bundle, provider_url=provider_url)
 
     def iter_updates(self, initial, scheduled):
 

--- a/pyup/providers/github.py
+++ b/pyup/providers/github.py
@@ -13,15 +13,18 @@ logger = logging.getLogger(__name__)
 
 
 class Provider(object):
-    def __init__(self, bundle, integration=False):
+    def __init__(self, bundle, integration=False, url=None):
         self.bundle = bundle
         self.integration = integration
+        self.url = url
 
     @classmethod
     def is_same_user(cls, this, that):
         return this.login == that.login
 
     def _api(self, token):
+        if self.url:
+            return Github(token, base_url=self.url, timeout=50)
         return Github(token, timeout=50)
 
     def get_user(self, token):

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -14,8 +14,9 @@ class BadTokenError(Exception):
 
 
 class Provider(object):
-    def __init__(self, bundle, intergration=False):
+    def __init__(self, bundle, intergration=False, url=None):
         self.bundle = bundle
+        self.url = url
         if intergration:
             raise NotImplementedError(
                 'Gitlab provider does not support integration mode')
@@ -27,7 +28,7 @@ class Provider(object):
     def _api(self, token):
         parts = token.split('@')
         if len(parts) == 1:
-            host = 'https://gitlab.com'
+            host = self.url or 'https://gitlab.com'
             auth = parts[0]
         elif len(parts) == 2:
             auth, host = parts

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -34,6 +34,17 @@ class ProviderTest(TestCase):
         prov._api("foo")
         github_mock.assert_called_once_with("foo", timeout=50)
 
+
+    @patch("pyup.providers.github.Github")
+    def test_api_different_host_in_provider_url(self, github_mock):
+        url = 'localhost'
+        token = 'foo'
+
+        prov = Provider(bundle=RequirementsBundle(), url=url)
+        prov._api(token)
+        github_mock.assert_called_once_with(token, base_url=url, timeout=50)
+
+
     def test_get_user(self):
         self.provider.get_user("foo")
         self.provider._api().get_user.assert_called_once_with()

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -39,7 +39,16 @@ class ProviderTest(TestCase):
         github_mock.assert_called_once_with("https://gitlab.com", "foo")
 
     @patch("pyup.providers.gitlab.Gitlab")
-    def test_api_different_host(self, github_mock):
+    def test_api_different_host_in_provider_url(self, github_mock):
+        url = 'localhost'
+        token = 'foo'
+
+        prov = Provider(bundle=RequirementsBundle(), url=url)
+        prov._api(token)
+        github_mock.assert_called_once_with(url, token)
+
+    @patch("pyup.providers.gitlab.Gitlab")
+    def test_api_different_host_in_token(self, github_mock):
         prov = Provider(bundle=RequirementsBundle())
         prov._api("foo@localhost")
         github_mock.assert_called_once_with("localhost", "foo")


### PR DESCRIPTION
This Pull Request adds a new option **provider_url**, for both Gitlab and GitHub

If it is not provided, the default URL for each provider will be used, i.e. gitlab.com and github.com

If an URL is provided, however, for custom GitLab or GitHub Enterprises instances, then this URL is used instead.

The previous way of providing a GitLab url, e.g. by adding @mygitlabhost to the token still works as expected.

This should resolve #240 