### PR TITLE
Handle crash when a private index doesn't support JSON

### DIFF
--- a/pyup/package.py
+++ b/pyup/package.py
@@ -10,7 +10,11 @@ def fetch_package(name, index_server=None):
     r = requests.get(url, timeout=3)
     if r.status_code != 200:
         return None
-    json = r.json()
+    try:
+        json = r.json()
+    except ValueError:
+        # JSON decoding error: ignore package
+        return None
     if index_server:
         releases = sorted(json["result"].keys(), key=lambda v: parse_version(v), reverse=True)
     else:

--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from json import JSONDecodeError
-
 from packaging.version import parse as parse_version
 from packaging.specifiers import SpecifierSet
 import requests
@@ -389,7 +387,8 @@ class Requirement(object):
             try:
                 self._package = fetch_package(self.name, self.index_server)
                 self._fetched_package = True
-            except JSONDecodeError:
+            except ValueError:
+                # Most likely failed to decode the response from the queried index
                 pass
         return self._package
 

--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -384,12 +384,8 @@ class Requirement(object):
     @property
     def package(self):
         if not self._fetched_package:
-            try:
-                self._package = fetch_package(self.name, self.index_server)
-                self._fetched_package = True
-            except ValueError:
-                # Most likely failed to decode the response from the queried index
-                pass
+            self._package = fetch_package(self.name, self.index_server)
+            self._fetched_package = True
         return self._package
 
     @property

--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from json import JSONDecodeError
+
 from packaging.version import parse as parse_version
 from packaging.specifiers import SpecifierSet
 import requests
@@ -384,8 +386,11 @@ class Requirement(object):
     @property
     def package(self):
         if not self._fetched_package:
-            self._package = fetch_package(self.name, self.index_server)
-            self._fetched_package = True
+            try:
+                self._package = fetch_package(self.name, self.index_server)
+                self._fetched_package = True
+            except JSONDecodeError:
+                pass
         return self._package
 
     @property

--- a/tests/data/elasticpypi.txt
+++ b/tests/data/elasticpypi.txt
@@ -1,0 +1,25 @@
+<html>
+  <head>
+  <title>Links for Django</title>
+  </head>
+  <body>
+    <h1>Links for Django</h1>
+
+    <a href="/dev/packages/Django-1.9.0-py3-none-any.whl">Django-1.9.0-py3-none-any.whl</a></br>
+
+    <a href="/dev/packages/Django-1.9.0.tar.gz">Django-1.9.0.tar.gz</a></br>
+
+    <a href="/dev/packages/Django-1.10.0-py3-none-any.whl">Django-1.10.0-py3-none-any.whl</a></br>
+
+    <a href="/dev/packages/Django-1.10.0.tar.gz">Django-1.10.0.tar.gz</a></br>
+
+    <a href="/dev/packages/Django-1.11.0-py3-none-any.whl">Django-1.11.0-py3-none-any.whl</a></br>
+
+    <a href="/dev/packages/Django-1.11.0.tar.gz">Django-1.11.0.tar.gz</a></br>
+
+    <a href="/dev/packages/Django-2.0.0-py3-none-any.whl">Django-2.0.0-py3-none-any.whl</a></br>
+
+    <a href="/dev/packages/Django-2.0.0.tar.gz">Django-2.0.0.tar.gz</a></br>
+
+  </body>
+</html>

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -41,8 +41,7 @@ class FetchPackageTestCase(TestCase):
             # ElasticPyPI has no JSON yet:
             # https://github.com/khornberg/elasticpypi/issues/48
             requests.get("https://some.foo/root/pypi/Django", text=f.read())
-        with self.assertRaises(ValueError):
-            fetch_package("Django", "https://some.foo/root/pypi/")
+        self.assertIsNone(fetch_package("Django", "https://some.foo/root/pypi/"))
 
     @requests_mock.mock()
     def test_fetch_packages(self, requests):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
+
+from json import JSONDecodeError
 from unittest import TestCase
 import requests_mock
 import os
@@ -35,6 +37,14 @@ class FetchPackageTestCase(TestCase):
              '1.2', '1.1.4', '1.1.3']
         )
 
+    @requests_mock.mock()
+    def test_fetch_package_elasticpypi(self, requests):
+        with open(os.path.dirname(os.path.realpath(__file__)) + "/data/elasticpypi.txt") as f:
+            # ElasticPyPI has no JSON yet:
+            # https://github.com/khornberg/elasticpypi/issues/48
+            requests.get("https://some.foo/root/pypi/Django", text=f.read())
+        with self.assertRaises(JSONDecodeError):
+            fetch_package("Django", "https://some.foo/root/pypi/")
 
     @requests_mock.mock()
     def test_fetch_packages(self, requests):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
-
-from json import JSONDecodeError
 from unittest import TestCase
 import requests_mock
 import os
@@ -43,7 +41,7 @@ class FetchPackageTestCase(TestCase):
             # ElasticPyPI has no JSON yet:
             # https://github.com/khornberg/elasticpypi/issues/48
             requests.get("https://some.foo/root/pypi/Django", text=f.read())
-        with self.assertRaises(JSONDecodeError):
+        with self.assertRaises(ValueError):
             fetch_package("Django", "https://some.foo/root/pypi/")
 
     @requests_mock.mock()


### PR DESCRIPTION
We use Elastic PyPI as an internal private index and it seems it doesn't support [the JSON API yet](https://github.com/khornberg/elasticpypi/issues/48).

Therefore, it returns a 200 response but not formatted as PyUP expects it's plain HTML rather than being a valid JSON. In this case, the whole update crashes. This is changing the behaviour to ignore the package in the private index and proceed with the rest of the requirements.