### PR TITLE
Regex case-insensitive.

### DIFF
--- a/pyup/config.py
+++ b/pyup/config.py
@@ -16,7 +16,8 @@ SCHEDULE_REGEX = re.compile(
     # or week/two weeks
     "|(week|two weeks))"
     # with an optional weekday
-    "( on (monday|tuesday|wednesday|thursday|friday|saturday|sunday))?"
+    "( on (monday|tuesday|wednesday|thursday|friday|saturday|sunday))?",
+    re.IGNORECASE
 )
 
 

--- a/pyup/config.py
+++ b/pyup/config.py
@@ -10,7 +10,7 @@ import re
 
 SCHEDULE_REGEX = re.compile(
     # has to begin with every
-    "^every "
+    r"^every "
     # followed by day/month
     "((day|month)$"
     # or week/two weeks


### PR DESCRIPTION
Recently we have hit a problem on https://github.com/mozilla-releng/build-puppet when we asked PyUp to make PRs "every week on Wednesday". 
The capitalization was a problem, which in return stopped PyUp to do what we expected it to do.

All I did was to add `, re.IGNORECASE` 
I could've used `re.I` - but I find it much cleaner to use the long name, as people will understand what's happening.