### PR TITLE
Fix get hashes return expression.

### DIFF
--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -464,7 +464,7 @@ class Requirement(object):
             sha256 = item.get("digests", {}).get("sha256", False)
             if sha256:
                 hashes.append({"hash": sha256})
-        return data["hashes"]
+        return hashes
 
     def update_content(self, content, update_hashes=True):
         if self.file_type == filetypes.tox_ini:


### PR DESCRIPTION
Hi! Thanks for the great project!

I encounter a problem while setting up this CLI tool with our private GitLab service.

We use `pipenv` tool together with `docker` the same way as described in your blog https://pyup.io/posts/pipfiles-and-docker/

Our `.pyup.yml`:

```yaml
requirements:
  - Pipfile
  - Pipfile.lock
```

I run this command:

    pyup --provider gitlab --repo=user/repo --user-token=...

Then I've got this error:

```
Update attrs to 18.2.0:   0%|                                                                                                                          | 0/22 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/usr/local/bin/pyup", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/pyup/cli.py", line 45, in main
    bot.update(branch=branch, initial=initial)
  File "/usr/local/lib/python3.6/site-packages/pyup/bot.py", line 125, in update
    scheduled=kwargs.get("scheduled", False)
  File "/usr/local/lib/python3.6/site-packages/pyup/bot.py", line 202, in apply_updates
    updates=updates,
  File "/usr/local/lib/python3.6/site-packages/pyup/bot.py", line 418, in commit_and_pull
    content = update.requirement.update_content(content, self.config.update_hashes)
  File "/usr/local/lib/python3.6/site-packages/pyup/requirements.py", line 496, in update_content
    for item in sorted(self.get_hashes(self.latest_version_within_specs), key=lambda x: x["hash"]):
  File "/usr/local/lib/python3.6/site-packages/pyup/requirements.py", line 467, in get_hashes
    return data["hashes"]
KeyError: 'hashes'
```

After this patch is applied:

```
Update attrs to 18.2.0:   0%|                                                                                                                          | 0/22 [00:00<?, ?it/s]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update attrs to 18.2.0.
Update django to 2.1.1:  18%|████████████████████▋                                                                                             | 4/22 [00:12<00:56,  3.13s/it]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update django to 2.1.1.
Update idna to 2.7:  45%|█████████████████████████████████████████████████████▏                                                               | 10/22 [00:31<00:36,  3.06s/it]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update idna to 2.7.
Update pyjwt to 1.6.4:  64%|████████████████████████████████████████████████████████████████████████▌                                         | 14/22 [00:43<00:24,  3.12s/it]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update pyjwt to 1.6.4.
Update requests to 2.19.1:  73%|████████████████████████████████████████████████████████████████████████████████                              | 16/22 [00:50<00:18,  3.15s/it]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update requests to 2.19.1.
Update urllib3 to 1.23:  82%|████████████████████████████████████████████████████████████████████████████████████████████▍                    | 18/22 [00:56<00:12,  3.14s/it]ERROR:pyup.bot:Empty commit at qubblr/okappi, unable to update Update urllib3 to 1.23.
Update pyflakes to 2.0.0: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 22/22 [01:09<00:00,  3.16s/it]
```

After this, our branch list looks like this

![untitled](https://user-images.githubusercontent.com/1862725/45790721-ea795c00-bc8e-11e8-909c-c2f02f7fb19b.png)

I'm not sure about errors in the log. Probably it occurs because the previous command run already submits the same changes to this branch. Let me know if there is anything I can do to collect more data about it.

Looks like it works with this little patch.

Regards, Artem.