### PR TITLE
Fix use of deprecated assertEquals() in tests

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -70,7 +70,7 @@ class BotPullRequestsTest(TestCase):
         bot._fetched_prs = False
         bot.provider.iter_issues = Mock(return_value=[])
         bot.pull_requests
-        self.assertEquals(bot.provider.iter_issues.call_count, 1)
+        self.assertEqual(bot.provider.iter_issues.call_count, 1)
 
 
 class BotRepoConfigTest(TestCase):
@@ -403,8 +403,8 @@ class CreateBranchTest(TestCase):
         bot.provider.is_empty_branch.return_value = True
         bot.create_branch("new-branch", delete_empty=True)
 
-        self.assertEquals(bot.provider.is_empty_branch.call_count, 1)
-        self.assertEquals(bot.provider.delete_branch.call_count, 1)
+        self.assertEqual(bot.provider.is_empty_branch.call_count, 1)
+        self.assertEqual(bot.provider.delete_branch.call_count, 1)
         self.assertEqual(len(bot.provider.create_branch.mock_calls), 2)
 
     def test_branch_not_empty(self):
@@ -414,7 +414,7 @@ class CreateBranchTest(TestCase):
         bot.provider.is_empty_branch.return_value = False
         bot.create_branch("new-branch", delete_empty=True)
 
-        self.assertEquals(bot.provider.is_empty_branch.call_count, 1)
+        self.assertEqual(bot.provider.is_empty_branch.call_count, 1)
         bot.provider.delete_branch.assert_not_called()
         self.assertEqual(len(bot.provider.create_branch.mock_calls), 1)
 
@@ -713,7 +713,7 @@ class CloseStalePRsTestCase(TestCase):
         self.pr.type = Mock()
         bot.close_stale_prs(self.update, self.pr, False)
 
-        self.assertEquals(self.pr.type.call_count, 0)
+        self.assertEqual(self.pr.type.call_count, 0)
 
     def test_no_pull_requests(self):
         bot = bot_factory(bot_token="foo")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -92,7 +92,7 @@ class ProviderTest(TestCase):
         req = self.provider.get_requirement_file(self.repo, "path", "branch")
         self.assertIsNotNone(req)
         self.provider.bundle.get_requirement_file_class.assert_called_once_with()
-        self.assertEquals(self.provider.bundle.get_requirement_file_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_requirement_file_class().call_count, 1)
 
         self.provider.get_file = Mock(return_value = (None, None))
         req = self.provider.get_requirement_file(self.repo, "path", "branch")
@@ -140,7 +140,7 @@ class ProviderTest(TestCase):
         self.repo.update_file.return_value = {"commit": Mock(), "content": Mock()}
         self.provider.get_committer_data = Mock(return_value = "foo@bar.com")
         self.provider.create_commit("path", "branch", "commit", "content", "sha", self.repo, "com")
-        self.assertEquals(self.repo.update_file.call_count, 1)
+        self.assertEqual(self.repo.update_file.call_count, 1)
 
         self.repo.update_file.side_effect = GithubException(data="", status=1)
         with self.assertRaises(GithubException):
@@ -220,7 +220,7 @@ class ProviderTest(TestCase):
 
         pr.head.ref = "pyup-bla"
         self.provider.close_pull_request(self.repo, self.repo, pr, "comment", prefix="pyup-")
-        self.assertEquals(self.repo.get_git_ref().delete.call_count, 1)
+        self.assertEqual(self.repo.get_git_ref().delete.call_count, 1)
 
         self.repo.get_pull.side_effect = UnknownObjectException(data="", status=1)
         data = self.provider.close_pull_request(self.repo, self.repo, Mock(), "comment",
@@ -230,13 +230,13 @@ class ProviderTest(TestCase):
     def test_create_pull_request_with_exceeding_body(self):
         body = ''.join(["a" for i in range(0, 65536 + 1)])
         self.provider.create_pull_request(self.repo, "title", body, "master", "new", False, [])
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
     def test_create_pull_request(self):
         self.provider.create_pull_request(self.repo, "title", "body", "master", "new", False, [])
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
         self.repo.create_pull.side_effect = GithubException(data="", status=1)
         with self.assertRaises(errors.NoPermissionError):
@@ -244,16 +244,16 @@ class ProviderTest(TestCase):
 
     def test_create_pull_request_with_label(self):
         self.provider.create_pull_request(self.repo, "title", "body", "master", "new", "some-label", [])
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
     def test_create_pull_request_with_assignees(self):
         self.provider.create_pull_request(self.repo, "title", "body", "master", "new",
                                           None, ["some-assignee"])
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
-        self.assertEquals(self.repo.get_issue.call_count, 1)
-        self.assertEquals(self.repo.get_issue().edit.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.repo.get_issue.call_count, 1)
+        self.assertEqual(self.repo.get_issue().edit.call_count, 1)
 
     def test_create_issue(self):
         self.assertIsNot(self.provider.create_issue(self.repo, "title", "body"), False)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -90,7 +90,7 @@ class ProviderTest(TestCase):
         req = self.provider.get_requirement_file(self.repo, "path", "branch")
         self.assertIsNotNone(req)
         self.provider.bundle.get_requirement_file_class.assert_called_once_with()
-        self.assertEquals(self.provider.bundle.get_requirement_file_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_requirement_file_class().call_count, 1)
 
         self.provider.get_file = Mock(return_value = (None, None))
         req = self.provider.get_requirement_file(self.repo, "path", "branch")
@@ -137,9 +137,9 @@ class ProviderTest(TestCase):
         file = Mock()
         self.repo.files.get.return_value = file
         self.provider.create_commit("path", "branch", "commit", "content", "sha", self.repo, "com")
-        self.assertEquals(self.repo.files.get.call_count, 1)
-        self.assertEquals(file.content, b64encode(b"content").decode())
-        self.assertEquals(file.encoding, "base64")
+        self.assertEqual(self.repo.files.get.call_count, 1)
+        self.assertEqual(file.content, b64encode(b"content").decode())
+        self.assertEqual(file.encoding, "base64")
         file.save.assert_called_with(branch="branch", commit_message="commit")
 
     def test_create_and_commit_file(self):
@@ -174,7 +174,7 @@ class ProviderTest(TestCase):
 
         mr.source_branch = "pyup-bla"
         self.provider.close_pull_request(self.repo, self.repo, mr, "comment", prefix="pyup-")
-        self.assertEquals(self.repo.branches.get().delete.call_count, 1)
+        self.assertEqual(self.repo.branches.get().delete.call_count, 1)
 
     def test_merge_pull_request(self):
         mr = Mock()
@@ -196,8 +196,8 @@ class ProviderTest(TestCase):
     def test_create_pull_request_with_exceeding_body(self):
         body = ''.join(["a" for i in range(0, 65536 + 1)])
         self.provider.create_pull_request(self.repo, "title", body, "master", "new", False, [], Config())
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
     @patch("pyup.providers.gitlab.Provider._merge_merge_request")
     def test_create_pull_request_merge_when_pipeline_succeeds(self, merge_mock):
@@ -212,13 +212,13 @@ class ProviderTest(TestCase):
 
     def test_create_pull_request(self):
         self.provider.create_pull_request(self.repo, "title", "body", "master", "new", False, [], Config())
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
     def test_create_pull_request_with_label(self):
         self.provider.create_pull_request(self.repo, "title", "body", "master", "new", "some-label", [], Config())
-        self.assertEquals(self.provider.bundle.get_pull_request_class.call_count, 1)
-        self.assertEquals(self.provider.bundle.get_pull_request_class().call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class.call_count, 1)
+        self.assertEqual(self.provider.bundle.get_pull_request_class().call_count, 1)
 
     def test_create_issue(self):
         self.assertIsNot(self.provider.create_issue(self.repo, "title", "body"), False)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -587,9 +587,9 @@ class RequirementTestCase(TestCase):
             self.assertFalse(r.needs_update)
 
     def test_convert_semver(self):
-        self.assertEquals({"major": 1, "minor": 2, "patch": 3}, Requirement.convert_semver("1.2.3"))
-        self.assertEquals({"major": 1, "minor": 2, "patch": 0}, Requirement.convert_semver("1.2"))
-        self.assertEquals({"major": 1, "minor": 0, "patch": 0}, Requirement.convert_semver("1"))
+        self.assertEqual({"major": 1, "minor": 2, "patch": 3}, Requirement.convert_semver("1.2.3"))
+        self.assertEqual({"major": 1, "minor": 2, "patch": 0}, Requirement.convert_semver("1.2"))
+        self.assertEqual({"major": 1, "minor": 0, "patch": 0}, Requirement.convert_semver("1"))
 
     def test_tabbed(self):
         req = Requirement.parse("Django==1.5\t\t#some-comment", 0)
@@ -897,7 +897,7 @@ class RequirementTestCase(TestCase):
         # test that the api is not called if the api key is not set
         settings.api_key = None
         r = Requirement.parse("pyupio", 0)
-        self.assertEquals(r.changelog, {})
+        self.assertEqual(r.changelog, {})
 
         # test the api is called if the api key is set
         settings.api_key = "foo"
@@ -908,7 +908,7 @@ class RequirementTestCase(TestCase):
         with open(os.path.dirname(os.path.realpath(__file__)) + "/data/pyup-changelog.json") as f:
             requests.get("https://pyup.io/api/v1/changelogs/pyupio/", text=f.read())
             log = r.changelog
-            self.assertEquals(len(log), 6)
+            self.assertEqual(len(log), 6)
 
 
 
@@ -1238,7 +1238,7 @@ class RequirementsBundleTestCase(TestCase):
             scheduled=False,
             config=None
         )
-        self.assertEquals(klass, req.get_initial_update_class())
+        self.assertEqual(klass, req.get_initial_update_class())
 
     def test_get_scheduled_update_class(self):
         req = RequirementsBundle()
@@ -1249,7 +1249,7 @@ class RequirementsBundleTestCase(TestCase):
             scheduled=True,
             config=config
         )
-        self.assertEquals(klass, req.get_scheduled_update_class())
+        self.assertEqual(klass, req.get_scheduled_update_class())
 
     def test_get_sequential_update_class(self):
         req = RequirementsBundle()
@@ -1258,7 +1258,7 @@ class RequirementsBundleTestCase(TestCase):
             scheduled=False,
             config=None
         )
-        self.assertEquals(klass, req.get_sequential_update_class())
+        self.assertEqual(klass, req.get_sequential_update_class())
 
     def test_get_updates(self):
         with patch('pyup.requirements.Requirement.package', return_value=Mock()):

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -251,7 +251,7 @@ class ScheduledUpdateTest(ScheduledUpdateBaseTest):
     def test_title_every_day(self, dt):
         dt.now.return_value = datetime(2016, 9, 13, 9, 21, 42, 702067)
         self.config.schedule = "every day"
-        self.assertEquals(
+        self.assertEqual(
             self.update.get_title(),
             "Scheduled daily dependency update on tuesday"
         )
@@ -260,7 +260,7 @@ class ScheduledUpdateTest(ScheduledUpdateBaseTest):
     def test_title_every_week(self, dt):
         dt.now.return_value = datetime(2016, 9, 16, 9, 21, 42, 702067)
         self.config.schedule = "every week on wednesday"
-        self.assertEquals(
+        self.assertEqual(
             self.update.get_title(),
             "Scheduled weekly dependency update for week 37"
         )
@@ -269,7 +269,7 @@ class ScheduledUpdateTest(ScheduledUpdateBaseTest):
     def test_title_every_two_weeks(self, dt):
         dt.now.return_value = datetime(2016, 9, 18, 9, 21, 42, 702067)
         self.config.schedule = "every two weeks on sunday"
-        self.assertEquals(
+        self.assertEqual(
             self.update.get_title(),
             "Scheduled biweekly dependency update for week 38"
         )
@@ -278,7 +278,7 @@ class ScheduledUpdateTest(ScheduledUpdateBaseTest):
     def test_title_every_month(self, dt):
         dt.now.return_value = datetime(2016, 12, 13, 9, 21, 42, 702067)
         self.config.schedule = "every month"
-        self.assertEquals(
+        self.assertEqual(
             self.update.get_title(),
             "Scheduled monthly dependency update for December"
         )
@@ -291,7 +291,7 @@ class ScheduledUpdateTest(ScheduledUpdateBaseTest):
     @patch("pyup.updates.datetime")
     def test_get_branch(self, dt):
         dt.now.return_value = datetime(2016, 12, 13, 9, 21, 42, 702067)
-        self.assertEquals(
+        self.assertEqual(
             self.update.get_branch(),
             "scheduled-update-2016-12-13"
         )


### PR DESCRIPTION
Hello,

This fixes several `assertEquals()` for `assertEqual()` in tests.