### PR TITLE
Rework how we do compatible releases

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -749,7 +749,6 @@ class RequirementTestCase(TestCase):
             r = Requirement.parse("django", 0)
             self.assertEqual(r.version, "1.9.1")
 
-        print("FILTER TEST")
         with patch('pyup.requirements.Requirement.package', new_callable=PropertyMock,
                    return_value=package_factory(
                        name="django",


### PR DESCRIPTION
Currently, compatible releases - that is, lines like 'Django~=1.7.2' -
are treat like fixed version - 'Django==1.7.2'. This is incorrect
behavior. In reality, 'Django~1.7.2' resolves to 'Django>=1.7.2,<1.8.0'
and these version specifiers can be used to avoid having to bump a
version repeatedly by ensuring the latest PATCH release of a
semantically versioned package is always installed.

Change how we treat these releases so that compatible packages behave as
expected. We do this by replacing the '~=A' format with '>=A,<B' format
specifiers, allowing us to use all the logic we have built up for
range-based specifiers.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Closes: #361