### PR TITLE
remove leading slash from .pyup.yml to fix bug on gitlab api

### DIFF
--- a/pyup/bot.py
+++ b/pyup/bot.py
@@ -71,7 +71,7 @@ class Bot(object):
 
     def get_repo_config(self, repo, branch=None, create_error_issue=True):
         branch = self.config.branch if branch is None else branch
-        content, _ = self.provider.get_file(repo, "/.pyup.yml", branch)
+        content, _ = self.provider.get_file(repo, ".pyup.yml", branch)
         if content is not None:
             try:
                 return yaml.safe_load(content)

--- a/pyup/bot.py
+++ b/pyup/bot.py
@@ -361,14 +361,14 @@ class Bot(object):
         branch = 'pyup-config'
         if self.create_branch(branch, delete_empty=True):
             content = self.config.generate_config_file(new_config)
-            _, content_file = self.provider.get_file(self.user_repo, '/.pyup.yml', branch)
+            _, content_file = self.provider.get_file(self.user_repo, '.pyup.yml', branch)
             if content_file:
                 # a config file exists, update and commit it
                 logger.info(
                     "Config file exists, updating config for sha {}".format(content_file.sha))
                 self.provider.create_commit(
                     repo=self.user_repo,
-                    path="/.pyup.yml",
+                    path=".pyup.yml",
                     branch=branch,
                     content=content,
                     commit_message="update pyup.io config file",
@@ -379,7 +379,7 @@ class Bot(object):
             # there's no config file present, write a new config file and commit it
             self.provider.create_and_commit_file(
                 repo=self.user_repo,
-                path="/.pyup.yml",
+                path=".pyup.yml",
                 branch=branch,
                 content=content,
                 commit_message="create pyup.io config file",

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -71,6 +71,8 @@ class Provider(object):
 
     def get_file(self, repo, path, branch):
         logger.info("Getting file at {} for branch {}".format(path, branch))
+        # remove unnecessary leading slash to avoid gitlab errors. See #375
+        path = path.lstrip('/')
         try:
             contentfile = repo.files.get(file_path=path, ref=branch)
         except GitlabGetError as e:


### PR DESCRIPTION
As reported in #374 the support for gitlab is broken. This is due to a change in the gitlab api. Gitlab dose not accept a urlencoded leading slash in a file path. Non urlencoded leading slashes are fine. A leading slash is used to receive the [pyup.yml](../blob/master/pyup/bot.py#L74). The the path is then urlencoded by the gitlab library.

There is no need to for the leading slash. At this point there is no previous file request which could fail a relative file path request. So I removed the slash. Which let the api call on gitlab work again. 

Fix #374