### PR TITLE
GitLab: merge with correct arguments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ History
 1.1.2a (current)
 ----------------
 * Current unstable
+* Fixed `#384`_ affecting GitLab automatic merge
+
+.. _#384: https://github.com/pyupio/pyup/issues/384
 
 1.1.1 (2020-05-01)
 ------------------

--- a/pyup/providers/gitlab.py
+++ b/pyup/providers/gitlab.py
@@ -171,7 +171,7 @@ class Provider(object):
         self.delete_branch(user_repo, source_branch, prefix)
 
     def _merge_merge_request(self, mr, config):
-        mr.merge(remove_source_branch=config.gitlab.should_remove_source_branch,
+        mr.merge(should_remove_source_branch=config.gitlab.should_remove_source_branch,
                  merge_when_pipeline_succeeds=True)
 
     def create_pull_request(self, repo, title, body, base_branch, new_branch, pr_label, assignees, config):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -211,7 +211,7 @@ class ProviderTest(TestCase):
         config = Config()
         self.provider._merge_merge_request(mr, config)
         mr.merge.assert_called_once_with(merge_when_pipeline_succeeds=True,
-                                         remove_source_branch=False)
+                                         source_remove_source_branch=False)
 
     def test_merge_pull_request_with_remove(self):
         mr = Mock()
@@ -220,7 +220,7 @@ class ProviderTest(TestCase):
         config.update_config({'gitlab': {'should_remove_source_branch': True}})
         self.provider._merge_merge_request(mr, config)
         mr.merge.assert_called_once_with(merge_when_pipeline_succeeds=True,
-                                         remove_source_branch=True)
+                                         source_remove_source_branch=True)
 
     def test_create_pull_request_with_exceeding_body(self):
         body = ''.join(["a" for i in range(0, 65536 + 1)])

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -211,7 +211,7 @@ class ProviderTest(TestCase):
         config = Config()
         self.provider._merge_merge_request(mr, config)
         mr.merge.assert_called_once_with(merge_when_pipeline_succeeds=True,
-                                         source_remove_source_branch=False)
+                                         should_remove_source_branch=False)
 
     def test_merge_pull_request_with_remove(self):
         mr = Mock()
@@ -220,7 +220,7 @@ class ProviderTest(TestCase):
         config.update_config({'gitlab': {'should_remove_source_branch': True}})
         self.provider._merge_merge_request(mr, config)
         mr.merge.assert_called_once_with(merge_when_pipeline_succeeds=True,
-                                         source_remove_source_branch=True)
+                                         should_remove_source_branch=True)
 
     def test_create_pull_request_with_exceeding_body(self):
         body = ''.join(["a" for i in range(0, 65536 + 1)])


### PR DESCRIPTION
Refer to issue #384 

GitLab merge is currently invoked with `remove_source_branch` and not as expected with `should_remove_source_branch`, which leads to Error 405, as the python-gitlab (refer to `https://github.com/python-gitlab/python-gitlab/pull/1121`) wrapper doesn't handle other arguments as query strings but post data, which isn't supported by GitLab. 