### PR TITLE
Commit messages can now be configured via config.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 ------------
 
 * Christophe Lecointe
+* Johannes Lippmann

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,8 +6,10 @@ History
 1.1.2a (current)
 ----------------
 * Current unstable
+* New feature `#274`_ allows customizing commit messages
 * Fixed `#384`_ affecting GitLab automatic merge
 
+.. _#274: https://github.com/pyupio/pyup/issues/274
 .. _#384: https://github.com/pyupio/pyup/issues/384
 
 1.1.1 (2020-05-01)

--- a/pyup/config.py
+++ b/pyup/config.py
@@ -41,6 +41,8 @@ class Config(object):
         self.label_prs = False
         self.schedule = ""
         self.assignees = []
+        self.commit_message_template_pin = "Pin {package_name} to latest version {new_version}"
+        self.commit_message_template_update = "Update {package_name} from {old_version} to {new_version}"
         self.gitlab = GitlabConfig()
         self.update = Config.UPDATE_ALL
         self.update_hashes = True

--- a/pyup/updates.py
+++ b/pyup/updates.py
@@ -45,16 +45,15 @@ class Update(dict):
         else:
             self[key] = [update]
 
-    @classmethod
-    def get_commit_message(cls, requirement):
+    def get_commit_message(self, requirement):
         if requirement.is_pinned:
-            return "Update {} from {} to {}".format(
-                requirement.key, requirement.version,
-                requirement.latest_version_within_specs
-            )
-        return "Pin {} to latest version {}".format(
-            requirement.key,
-            requirement.latest_version_within_specs
+            message_template = self.config.commit_message_template_update or "Update {package_name} from {old_version} to {new_version}"
+        else:
+            message_template = self.config.commit_message_template_pin or "Pin {package_name} to latest version {new_version}"
+        return message_template.format(
+            package_name=requirement.key,
+            old_version=requirement.version,
+            new_version=requirement.latest_version_within_specs
         )
 
     def should_update(self, requirement, requirement_file):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,8 @@ class ConfigTestCase(TestCase):
         self.assertEqual(config.requirements, [])
         self.assertEqual(config.schedule, "")
         self.assertEqual(config.assignees, [])
+        self.assertEqual(config.commit_message_template_pin, "Pin {package_name} to latest version {new_version}")
+        self.assertEqual(config.commit_message_template_update, "Update {package_name} from {old_version} to {new_version}")
         self.assertEqual(config.update, "all")
         self.assertEqual(config.pr_prefix, "")
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -91,12 +91,19 @@ class UpdateCreateUpdateKeyTest(UpdateBaseTest):
 
 
 class UpdateGetCommitMessageTest(UpdateBaseTest):
+
+    def setUp(self):
+        super(UpdateGetCommitMessageTest, self).setUp()
+        self.config.commit_message_template_pin = "Version {new_version} for {package_name} is fix now."
+        self.config.commit_message_template_update = "{old_version} is old, update {package_name} to {new_version}."
+        self.update = ScheduledUpdate([], self.config)
+
     def test_unpinned_requirement(self):
         req = Mock()
         req.key = "django"
         req.is_pinned = False
         req.latest_version_within_specs = "1.10"
-        self.assertEqual(Update.get_commit_message(req), "Pin django to latest version 1.10")
+        self.assertEqual(self.update.get_commit_message(req), "Version 1.10 for django is fix now.")
 
     def test_pinned_requirement(self):
         req = Mock()
@@ -104,7 +111,7 @@ class UpdateGetCommitMessageTest(UpdateBaseTest):
         req.is_pinned = True
         req.latest_version_within_specs = "1.10"
         req.version = "1.0"
-        self.assertEqual(Update.get_commit_message(req), "Update django from 1.0 to 1.10")
+        self.assertEqual(self.update.get_commit_message(req), "1.0 is old, update django to 1.10.")
 
 
 class UpdateInitTestCase(UpdateBaseTest):


### PR DESCRIPTION
Closes Issue #274.

The default values for commit messages stayed the same, but are
now always read from the config (instead of magic strings in the
`Update.get_commit_message` method).

This introduces two new settings for the config:
- `commit_message_template_pin` (for pinning commits)
- `commit_message_template_update` (for update commits)

They should be set to strings. Within these strings the substrings
"{package_name}", "{old_version}" and "{new_version}" will be
replaced with their respective values.

### Technical

The unittests are testing variants of the default messages. This
ensures that the config values are really read from the config
instead of assuming the default values.

The method Update.get_commit_message is not a classmethod anymore. This is because there can't be commit messages without providing a config from which the template can be read. This seemed like the simplest solution to me.

### Documentation

I would like to document the new options, but I couldn't find the place to do it other then commit-message and PR-description.