### PR TITLE
Fix bad return of hashes

### DIFF
--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -470,7 +470,7 @@ class Requirement(object):
             sha256 = item.get("digests", {}).get("sha256", False)
             if sha256:
                 hashes.append({"hash": sha256})
-        return data["hashes"]
+        return hashes
 
     def update_content(self, content, update_hashes=True):
         if self.file_type == filetypes.tox_ini:


### PR DESCRIPTION
I might be missing something, but I'm not sure how the code is supposed to work in its current form - when I use debug logging, `data` quite clearly does not contain `hashes`, and the block above this pretty clear is meant to built up the hashes that the caller wants.