### PR TITLE
Fixing requirements object not iterable on bad schema.

### DIFF
--- a/pyup/config.py
+++ b/pyup/config.py
@@ -53,6 +53,8 @@ class Config(object):
         for key, value in d.items():
             if hasattr(self, key):
                 if key == "requirements":
+                    if not value:
+                        continue
                     items, value = value, []
                     for item in items:
                         if isinstance(item, basestring):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,6 +121,17 @@ class ConfigTestCase(TestCase):
         self.assertEqual(config.requirements[1].pin, True)
         self.assertEqual(config.requirements[1].compile.specs, ["baz.in", "foo.in"])
 
+    def test_update_with_invalid_requirements_config(self):
+        update = {
+            "requirements": None
+        }
+        config = Config()
+        
+        self.assertEqual(config.requirements, [])
+        config.update_config(update)
+        self.assertEqual(config.requirements, [])
+        self.assertNotEqual(config.requirements, None)
+
     def test_valid_schedule(self):
         config = Config()
 


### PR DESCRIPTION
This will avoid raise "'NoneType' object is not iterable" error when user has a bad schema regarding `requirements.txt` on `.pyup.yml` file. 

Example schema that was triggering the error:

```
# Specify requirement files by hand, default is empty
# default: empty
# allowed: list
requirements:
#  - requirements/staging.txt:
```

Should we warn users about the bad schema? And how about the documentation (.pyup.yml example file), maybe the "default empty" is leading users to do that, and I think is in certain way controversial, since below says "allowed: list".