### PR TITLE
Check for regex only if we have string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 1.1.2a (current)
 ----------------
 * Current unstable
+* Schedule wont break config reading if it is not a string
 * New feature `#274`_ allows customizing commit messages
 * Fixed `#384`_ affecting GitLab automatic merge
 

--- a/pyup/config.py
+++ b/pyup/config.py
@@ -136,7 +136,10 @@ class Config(object):
                                                                    Config.UPDATE_INSECURE_TYPO)
 
     def is_valid_schedule(self):
-        return SCHEDULE_REGEX.search(self.schedule) if type(self.schedule) == str else None
+        if isinstance(self.schedule, str):
+            return SCHEDULE_REGEX.search(self.schedule)
+        else:
+            return None
 
     def __repr__(self):
         return str(self.__dict__)

--- a/pyup/config.py
+++ b/pyup/config.py
@@ -134,7 +134,7 @@ class Config(object):
                                                                    Config.UPDATE_INSECURE_TYPO)
 
     def is_valid_schedule(self):
-        return SCHEDULE_REGEX.search(self.schedule) is not None
+        return SCHEDULE_REGEX.search(self.schedule) if type(self.schedule) == str else None
 
     def __repr__(self):
         return str(self.__dict__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,6 +153,9 @@ class ConfigTestCase(TestCase):
                 "every month on tuesday",
                 "some other crap",
                 "every bla",
+                1,
+                [1, 2, 3],
+                {'every': 'week'},
                 "foo"]:
             config.schedule = sched
             self.assertFalse(config.is_valid_schedule())


### PR DESCRIPTION
This PR will increase the resistance of our code to errors when non-string value for "schedule" was passed: `expected string or bytes-like object`