### PR TITLE
Fix : Create Session object, over multiple requests.get

### DIFF
--- a/pyup/package.py
+++ b/pyup/package.py
@@ -4,10 +4,10 @@ from packaging.version import parse as parse_version
 import requests
 
 
-def fetch_package(name, index_server=None):
+def fetch_package(name, index_server=None,session=requests.Session()):
     url = index_server + name if index_server else \
         "https://pypi.org/pypi/{name}/json".format(name=name)
-    r = requests.get(url, timeout=3)
+    r = session.get(url, timeout=3)
     if r.status_code != 200:
         return None
     json = r.json()

--- a/pyup/requirements.py
+++ b/pyup/requirements.py
@@ -222,7 +222,7 @@ class Requirement(object):
         self._package = None
         self.file_type = file_type
         self.pipfile = None
-
+        self.session = requests.Session()
         self.hashCmp = (
             self.key,
             self.specs,
@@ -390,7 +390,7 @@ class Requirement(object):
     @property
     def package(self):
         if not self._fetched_package:
-            self._package = fetch_package(self.name, self.index_server)
+            self._package = fetch_package(self.name, self.index_server,self.session)
             self._fetched_package = True
         return self._package
 
@@ -421,7 +421,7 @@ class Requirement(object):
         if self._changelog is None:
             self._changelog = OrderedDict()
             if settings.api_key:
-                r = requests.get(
+                r = self.session.get(
                     "https://pyup.io/api/v1/changelogs/{}/".format(self.key),
                     headers={"X-Api-Key": settings.api_key}
                 )
@@ -460,7 +460,7 @@ class Requirement(object):
         return self.name
 
     def get_hashes(self, version):
-        r = requests.get('https://pypi.org/pypi/{name}/{version}/json'.format(
+        r = self.session.get('https://pypi.org/pypi/{name}/{version}/json'.format(
             name=self.key,
             version=version
         ))


### PR DESCRIPTION
This addresses #341  

In short, essentially the requests `get()` method creates a new Session object each time it's called.  By creating a Session it'll only create one session object. Making it more efficient!  


Tests: 
```
----------------------------------------------------------------------
Ran 271 tests in 0.343s
OK

```