### PR TITLE
Normalizing path of requirement files

### DIFF
--- a/pyup/bot.py
+++ b/pyup/bot.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
+from os.path import normpath
 import logging
 import yaml
 from .requirements import RequirementsBundle
@@ -509,6 +510,7 @@ class Bot(object):
     # needs to be updated too
     def add_requirement_file(self, path, sha=None):
         logger.info("Adding requirement file at {}".format(path))
+        path = normpath(path)
         branch = sha if sha is not None else self.config.branch
         if not self.req_bundle.has_file_in_path(path):
             req_file = self.provider.get_requirement_file(


### PR DESCRIPTION
A requirements file could contain a relative link to another requirements file. If the link contains a ```..``` it can not be handled by the GitLab api. 

A short example:
The file requirements/production.txt contains the following:
```
-r ../subproject/other_requirements.txt
```
Pyup adds the file path ```requirements/../subproject/other_requirements.txt``` to the list of requirement files. The request to fetch this file from the GitLab api is then responded with an HTTP 400 Error. 

By normalizing the file path before it is added this error is resolved. In our example the file path then would be ```subproject/other_requirements.txt```.
