### PR TITLE
Update get_committer_data for latest PyGithub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ install: pip install -U tox
 language: python
 matrix:
   include:
+  - env: TOXENV=py39
+    python: 3.9.1
   - env: TOXENV=py38
     python: 3.8.2
   - env: TOXENV=py37
     python: 3.7.7
   - env: TOXENV=py36
     python: 3.6.10
-  - env: TOXENV=py35
-    python: 3.5.9
 script: tox

--- a/pyup/providers/github.py
+++ b/pyup/providers/github.py
@@ -192,8 +192,8 @@ class Provider(object):
             email = committer.email
         else:
             for item in committer.get_emails():
-                if item["primary"]:
-                    email = item["email"]
+                if item.primary:
+                    email = item.email
         if email is None:
             msg = "Unable to get {login}'s email adress. " \
                   "You may have to add the scope user:email".format(login=committer.login)

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,13 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     entry_points={
         'console_scripts': [
             'pyup = pyup.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     "requests",
-    "pygithub>=1.43.3",
+    "pygithub>=1.55",
     "click",
     "tqdm",
     "pyyaml>=4.2b4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 
 [testenv]
 setenv =


### PR DESCRIPTION
v1.55 of PyGithub changed `get_emails` to return a named tuple (#1890)
rather than a dict directly from the decoded API response.

Update the code to access the fields as a property rather than by index
& bump the pin so 1.55 is the minimum version.

Fixes #409